### PR TITLE
2020-08-06 11:57:54 修复HD钱包通过助记词导出后再以普通钱包导入时钱包地址不对应的问题

### DIFF
--- a/source/platonWallet/Models/Wallet/Keystore.swift
+++ b/source/platonWallet/Models/Wallet/Keystore.swift
@@ -142,7 +142,7 @@ public struct Keystore {
     }
     
     /// 通过Keystore生成母地址
-    func generateHDParentAddress() -> String {
+    func generateRootWalletAddress() -> String {
         let publicKey = WalletUtil.publicKeyFromPrivateKey(generateRootPrivateKey(from: self.hdNode!))
         let originAddress = try! WalletUtil.addressFromPublicKey(publicKey, eip55: true)
         return originAddress

--- a/source/platonWallet/Modules/WalletService/WalletService.swift
+++ b/source/platonWallet/Modules/WalletService/WalletService.swift
@@ -123,7 +123,7 @@ public final class WalletService {
                 }
             } else {
                 // 分层钱包
-                wallet = Wallet(uuid: keystore.generateHDParentAddress(), name: name, keystoreObject: keystore, isHD: true, pathIndex: 0, parentId: nil)
+                wallet = Wallet(uuid: keystore.generateRootWalletAddress(), name: name, keystoreObject: keystore, isHD: true, pathIndex: 0, parentId: nil)
                 var subWallets: [Wallet] = []
                 for i: Int in 0..<30 {
                     let subWalletItem = Wallet(uuid: keystore.generateHDSubAddress(index: i), name: "\(name)_\(i + 1)", keystoreObject: keystore, isHD: true, pathIndex: Int(i), parentId: wallet.uuid)
@@ -213,7 +213,7 @@ public final class WalletService {
             var wallet: Wallet!
             if physicalType == .normal {
                 // 普通钱包
-                wallet = Wallet(uuid: keystore.generateHDSubAddress(index: 0), name: name, keystoreObject: keystore, isHD: false, pathIndex: 0, parentId: nil)
+                wallet = Wallet(uuid: keystore.generateRootWalletAddress(), name: name, keystoreObject: keystore, isHD: false, pathIndex: 0, parentId: nil)
                 wallet.isBackup = true
                 DispatchQueue.main.async {
                     do {
@@ -228,7 +228,7 @@ public final class WalletService {
                 }
             } else {
                 // 分层钱包
-                wallet = Wallet(uuid: keystore.generateHDParentAddress(), name: name, keystoreObject: keystore, isHD: true, pathIndex: 0, parentId: nil)
+                wallet = Wallet(uuid: keystore.generateRootWalletAddress(), name: name, keystoreObject: keystore, isHD: true, pathIndex: 0, parentId: nil)
                 for i: Int in 0..<30 {
                     let subWalletItem = Wallet(uuid: keystore.generateHDSubAddress(index: i), name: "\(name)_\(i + 1)", keystoreObject: keystore, isHD: true, pathIndex: Int(i), parentId: wallet.uuid)
                     wallet.subWallets.append(subWalletItem)

--- a/source/platonWallet/UI/ViewController/Asset/views/AssetWalletsHeaderView.swift
+++ b/source/platonWallet/UI/ViewController/Asset/views/AssetWalletsHeaderView.swift
@@ -94,6 +94,7 @@ class AssetWalletsHeaderView: UIView {
         controller.onwalletsSelect = { [weak self] in
             guard let self = self else { return }
             let rowModels = self.viewModel.walletViewModels.value
+            self.collectionView.reloadData()
             for (i, v) in rowModels.enumerated() {
                 if let md = v as? AssetWalletViewModel {
                     if md.isWalletSelected == true {
@@ -107,7 +108,6 @@ class AssetWalletsHeaderView: UIView {
                     }
                 }
             }
-            self.collectionView.reloadData()
         }
 //        controller.onExchangeWalletToDisplay = {[weak self](walletAddress) in
 //            guard let self = self else { return }


### PR DESCRIPTION
领取记录列表，钱包地址按照前6后6显示; 委托交易页面加上可选择切换钱包地址的图标；修复未备份助记词的HD钱包首页安全提醒中的“备份”按钮点击无响应的问题；修复HD钱包转账输入密码点击确认按钮发生闪退；委托记录列表，钱包地址按照前6后6显示；委托记录、领取记录列表日期格式优化，月、日间增加分隔符；钱包管理列表HD钱包名称下面的地址应隐藏不展示；修复委托页面更换钱包后，实际委托还是上一个钱包的地址的情况；